### PR TITLE
Add docs badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Build Status](https://travis-ci.org/freemle/freemle-ruby.svg)](https://travis-ci.org/freemle/freemle-ruby)
 [![Coverage Status](https://coveralls.io/repos/freemle/freemle-ruby/badge.png)](https://coveralls.io/r/freemle/freemle-ruby)
 [![Code Climate](https://codeclimate.com/github/freemle/freemle-ruby.png)](https://codeclimate.com/github/freemle/freemle-ruby)
+[![Inline docs](http://inch-pages.github.io/github/freemle/freemle-ruby.png)](http://inch-pages.github.io/github/freemle/freemle-ruby)
 
 A Ruby interface to the [Freemle](https://www.freemle.com/) REST API.
 


### PR DESCRIPTION
I just added the badge you requested to your README: ![Inline docs](http://inch-pages.github.io/github/freemle/freemle-ruby.png)

Your status page for this project is http://inch-pages.github.io/github/freemle/freemle-ruby

Thanks for giving this a shot!
