### PR TITLE
Add invoice download action

### DIFF
--- a/jortt.gemspec
+++ b/jortt.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'rest-client', '~> 2.0'
 
-  spec.add_development_dependency 'bundler', '~> 1.0'
+  spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'codecov', '~> 0.1'
   spec.add_development_dependency 'rake', '~> 12.0'
   spec.add_development_dependency 'rspec', '~> 3.7'

--- a/lib/jortt.rb
+++ b/lib/jortt.rb
@@ -1,3 +1,4 @@
+require 'jortt/error'
 require 'jortt/client'
 require 'jortt/client/version'
 

--- a/lib/jortt/client/invoices.rb
+++ b/lib/jortt/client/invoices.rb
@@ -45,6 +45,12 @@ module Jortt # :nodoc:
         end
       end
 
+      def download(id)
+        resource["id/#{id}"].get(params: {format: "pdf"}).body
+      rescue RestClient::Exception => error
+        raise Jortt::Error.new(error.message, error.response)
+      end
+
       def search(query)
         resource['search'].get(params: {query: query}) do |response|
           JSON.parse(response.body)

--- a/lib/jortt/error.rb
+++ b/lib/jortt/error.rb
@@ -1,0 +1,14 @@
+module Jortt
+  ##
+  # Request error class, has a hash with the error response when possible
+  class Error < StandardError
+    attr_reader :errors
+
+    def initialize(message, response)
+      if response.code == 400
+        json = JSON.parse(response.body)
+        @errors = json["errors"] if json.key?("errors")
+      end
+    end
+  end
+end

--- a/spec/jortt/client/invoices_spec.rb
+++ b/spec/jortt/client/invoices_spec.rb
@@ -28,6 +28,26 @@ describe Jortt::Client::Invoices do
     it { should eq('id' => 'foo') }
   end
 
+  describe '#download' do
+    subject { invoices.download('foo') }
+
+    context 'with valid id' do
+      before do
+        stub_request(:get, 'http://foo/invoices/id/foo?format=pdf').
+          to_return(status: 200, body: 'pdf body')
+      end
+      it { should eq('pdf body') }
+    end
+
+    context 'with invalid id' do
+      before do
+        stub_request(:get, 'http://foo/invoices/id/foo?format=pdf').
+          to_return(status: 400, body: '{"errors":{"invoice_id":{"code":"not_found"}}}')
+      end
+      it { expect { subject }.to raise_error(Jortt::Error) }
+    end
+  end
+
   describe '#search' do
     subject { invoices.search('terms') }
     before do

--- a/spec/jortt/client_spec.rb
+++ b/spec/jortt/client_spec.rb
@@ -23,7 +23,7 @@ describe Jortt::Client do
   end
 
   context 'configured' do
-    let(:client) { described_class.new(app_name: 'app', api_key: 'secret') }
+    let(:client) { described_class.new(base_url: 'foo', app_name: 'app', api_key: 'secret') }
 
     describe '#customers' do
       subject { client.customers }
@@ -38,6 +38,25 @@ describe Jortt::Client do
     describe '#invoice' do
       subject { client.invoice('foo') }
       it { should be_instance_of(described_class::Invoice) }
+    end
+
+    describe 'error responses' do
+      before do
+        stub_request(:get, 'http://foo/invoices/id/foo?format=pdf').
+          to_return(status: 400, body: '{"errors":{"invoice_id":{"code":"not_found"}}}')
+      end
+
+      it 'wraps RestClient errors' do
+        expect { client.invoices.download('foo') }.to raise_error(Jortt::Error)
+      end
+
+      it 'exposes the json errors' do
+        begin
+          client.invoices.download('foo')
+        rescue Jortt::Error => error
+          expect(error.errors).to eq({"invoice_id" => {"code" => "not_found"}})
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Add action to download the pdf as data.

Also introduces an `Error` class, since Jortt responds with JSON errors and the caller of `#download` expects PDF data, this error class is raised whenever Jortt responds with errors.