### PR TITLE
Add error guards around all requests

### DIFF
--- a/lib/jortt/client.rb
+++ b/lib/jortt/client.rb
@@ -1,3 +1,4 @@
+require 'jortt/client/base'
 require 'jortt/client/customers'
 require 'jortt/client/invoices'
 require 'jortt/client/invoice'
@@ -65,21 +66,6 @@ module Jortt
     # @return [ Jortt::Client::Invoice ] entry to the invoice resource.
     def invoice(invoice_id)
       Jortt::Client::Invoice.new(self, invoice_id)
-    end
-
-  private
-
-    def with_valid_response(&block)
-      block.call
-    rescue RestClient::Exception => error
-      raise Jortt::Error.new(error.message, error.response)
-    end
-
-    def with_valid_json(&block)
-      with_valid_response do
-        response = block.call
-        JSON.parse(response.body)
-      end
     end
   end
 end

--- a/lib/jortt/client.rb
+++ b/lib/jortt/client.rb
@@ -67,5 +67,19 @@ module Jortt
       Jortt::Client::Invoice.new(self, invoice_id)
     end
 
+  private
+
+    def with_valid_response(&block)
+      block.call
+    rescue RestClient::Exception => error
+      raise Jortt::Error.new(error.message, error.response)
+    end
+
+    def with_valid_json(&block)
+      with_valid_response do
+        response = block.call
+        JSON.parse(response.body)
+      end
+    end
   end
 end

--- a/lib/jortt/client/base.rb
+++ b/lib/jortt/client/base.rb
@@ -1,0 +1,23 @@
+module Jortt # :nodoc:
+  class Client # :nodoc:
+
+    ##
+    # This class is the base class for all sub clients
+    class Base
+    private
+
+      def with_valid_response(&block)
+        block.call
+      rescue RestClient::Exception => error
+        raise Jortt::Error.new(error.message, error.response)
+      end
+
+      def with_valid_json(&block)
+        with_valid_response do
+          response = block.call
+          JSON.parse(response.body)
+        end
+      end
+    end
+  end
+end

--- a/lib/jortt/client/customers.rb
+++ b/lib/jortt/client/customers.rb
@@ -7,7 +7,7 @@ module Jortt # :nodoc:
     # Exposes the operations available for a collection of customers.
     #
     # @see { Jortt::Client.customers }
-    class Customers < Client
+    class Customers < Base
 
       def initialize(config)
         @resource = RestClient::Resource.new(

--- a/lib/jortt/client/customers.rb
+++ b/lib/jortt/client/customers.rb
@@ -7,7 +7,7 @@ module Jortt # :nodoc:
     # Exposes the operations available for a collection of customers.
     #
     # @see { Jortt::Client.customers }
-    class Customers
+    class Customers < Client
 
       def initialize(config)
         @resource = RestClient::Resource.new(
@@ -24,8 +24,8 @@ module Jortt # :nodoc:
       #   Jortt::Client.customers.all(page: 3, per_page: 10)
       #
       def all(page: 1, per_page: 50)
-        resource['all'].get(params: {page: page, per_page: per_page}) do |res|
-          JSON.parse(res.body)
+        with_valid_json do
+          resource['all'].get(params: {page: page, per_page: per_page})
         end
       end
 
@@ -47,8 +47,8 @@ module Jortt # :nodoc:
       #     }
       #   )
       def create(payload)
-        resource.post(JSON.generate('customer' => payload)) do |response|
-          JSON.parse(response.body)
+        with_valid_json do
+          resource.post(JSON.generate('customer' => payload))
         end
       end
 
@@ -69,8 +69,8 @@ module Jortt # :nodoc:
       #
       # @since 1.0.0
       def search(query)
-        resource.get(params: {query: query}) do |response|
-          JSON.parse(response.body)
+        with_valid_json do
+          resource.get(params: {query: query})
         end
       end
 

--- a/lib/jortt/client/invoice.rb
+++ b/lib/jortt/client/invoice.rb
@@ -7,7 +7,7 @@ module Jortt # :nodoc:
     # Exposes the operations available for a single invoice.
     #
     # @see { Jortt::Client.invoice }
-    class Invoice < Client
+    class Invoice < Base
 
       def initialize(config, id)
         @config = config

--- a/lib/jortt/client/invoice.rb
+++ b/lib/jortt/client/invoice.rb
@@ -7,7 +7,7 @@ module Jortt # :nodoc:
     # Exposes the operations available for a single invoice.
     #
     # @see { Jortt::Client.invoice }
-    class Invoice
+    class Invoice < Client
 
       def initialize(config, id)
         @config = config
@@ -35,8 +35,8 @@ module Jortt # :nodoc:
           user: config.app_name,
           password: config.api_key,
         )
-        resource.post(JSON.generate(payload)) do |response|
-          JSON.parse(response.body)
+        with_valid_json do
+          resource.post(JSON.generate(payload))
         end
       end
 
@@ -55,8 +55,8 @@ module Jortt # :nodoc:
           user: config.app_name,
           password: config.api_key,
         )
-        resource.post(JSON.generate(payload)) do |res|
-          JSON.parse(res.body)
+        with_valid_json do
+          resource.post(JSON.generate(payload))
         end
       end
 

--- a/lib/jortt/client/invoices.rb
+++ b/lib/jortt/client/invoices.rb
@@ -7,7 +7,7 @@ module Jortt # :nodoc:
     # Exposes the operations available for a collection of invoices.
     #
     # @see { Jortt::Client.invoices }
-    class Invoices
+    class Invoices < Client
 
       def initialize(config)
         @resource = RestClient::Resource.new(
@@ -34,32 +34,32 @@ module Jortt # :nodoc:
       #     }]
       #   )
       def create(payload)
-        resource.post(JSON.generate('invoice' => payload)) do |response|
-          JSON.parse(response.body)
+        with_valid_json do
+          resource.post(JSON.generate('invoice' => payload))
         end
       end
 
       def get(id)
-        resource["id/#{id}"].get do |response|
-          JSON.parse(response.body)
+        with_valid_json do
+          resource["id/#{id}"].get
         end
       end
 
       def download(id)
-        resource["id/#{id}"].get(params: {format: "pdf"}).body
-      rescue RestClient::Exception => error
-        raise Jortt::Error.new(error.message, error.response)
+        with_valid_response do
+          resource["id/#{id}"].get(params: {format: "pdf"}).body
+        end
       end
 
       def search(query)
-        resource['search'].get(params: {query: query}) do |response|
-          JSON.parse(response.body)
+        with_valid_json do
+          resource['search'].get(params: {query: query})
         end
       end
 
       def status(invoice_status, page: 1, per_page: 100)
-        resource["status/#{invoice_status}"].get(params: {page: page, per_page: per_page}) do |response|
-          JSON.parse(response.body)
+        with_valid_json do
+          resource["status/#{invoice_status}"].get(params: {page: page, per_page: per_page})
         end
       end
 

--- a/lib/jortt/client/invoices.rb
+++ b/lib/jortt/client/invoices.rb
@@ -7,7 +7,7 @@ module Jortt # :nodoc:
     # Exposes the operations available for a collection of invoices.
     #
     # @see { Jortt::Client.invoices }
-    class Invoices < Client
+    class Invoices < Base
 
       def initialize(config)
         @resource = RestClient::Resource.new(

--- a/spec/jortt/client/invoices_spec.rb
+++ b/spec/jortt/client/invoices_spec.rb
@@ -21,11 +21,22 @@ describe Jortt::Client::Invoices do
 
   describe '#get' do
     subject { invoices.get('foo') }
-    before do
-      stub_request(:get, 'http://foo/invoices/id/foo').
-        to_return(status: 200, body: '{"id": "foo"}')
+
+    context 'with valid id' do
+      before do
+        stub_request(:get, 'http://foo/invoices/id/foo').
+          to_return(status: 200, body: '{"id": "foo"}')
+      end
+      it { should eq('id' => 'foo') }
     end
-    it { should eq('id' => 'foo') }
+
+    context 'with invalid id' do
+      before do
+        stub_request(:get, 'http://foo/invoices/id/foo').
+          to_return(status: 400, body: '{"errors":{"invoice_id":{"code":"not_found"}}}')
+      end
+      it { expect { subject }.to raise_error(Jortt::Error) }
+    end
   end
 
   describe '#download' do


### PR DESCRIPTION
Responses aren't validated when using the block notation with `RestClient`.

Replaced all block notations with regular calls and catch `RestClient` errors and wrap them in a `Jortt::Error`. Also added a convenience wrapper to automatically parse the JSON body if the response was valid.
