### PR TITLE
Fix error on tradenames request without tradenames

### DIFF
--- a/lib/jortt/client.rb
+++ b/lib/jortt/client.rb
@@ -167,7 +167,11 @@ module Jortt
       response = yield
       return true if response.status == 204
 
-      response.parsed.fetch('data')
+      if response.parsed.is_a? Hash
+        response.parsed.fetch('data')
+      else
+        response.parsed
+      end
     rescue OAuth2::Error => e
       raise Error.from_response(e.response)
     end

--- a/spec/fixtures/vcr_cassettes/Jortt_Client_Tradenames/_index/with_no_tradenames_available/returns_an_empty_array.yml
+++ b/spec/fixtures/vcr_cassettes/Jortt_Client_Tradenames/_index/with_no_tradenames_available/returns_an_empty_array.yml
@@ -1,0 +1,100 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://app.jortt.nl/oauth-provider/oauth/token
+    body:
+      encoding: UTF-8
+      string: grant_type=client_credentials&scope=invoices%3Aread+invoices%3Awrite+customers%3Aread+customers%3Awrite+organizations%3Aread
+    headers:
+      User-Agent:
+      - Faraday v2.7.6
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 22 Jun 2023 06:17:05 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      Cache-Control:
+      - private, no-store
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Pragma:
+      - no-cache
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Request-Id:
+      - a50760a5-19dd-470f-8e9a-1aa523973eef
+      X-Download-Options:
+      - noopen
+      Etag:
+      - W/"0ba8a5f5b1719329d12a6e998a397b56"
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Runtime:
+      - '0.412512'
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - Phusion Passenger(R)
+      Server:
+      - nginx + Phusion Passenger(R)
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"access_token","token_type":"Bearer","expires_in":7200,"scope":"invoices:read
+        invoices:write customers:read customers:write organizations:read","created_at":1687414625}'
+  recorded_at: Thu, 22 Jun 2023 06:17:05 GMT
+- request:
+    method: get
+    uri: https://api.jortt.nl/tradenames
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v2.7.6
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 22 Jun 2023 06:17:05 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '2'
+      Connection:
+      - keep-alive
+      Server:
+      - Apache
+      Vary:
+      - X-Forwarded-For
+      Status:
+      - 200 OK
+    body:
+      encoding: UTF-8
+      string: "[]"
+  recorded_at: Thu, 22 Jun 2023 06:17:05 GMT
+recorded_with: VCR 6.1.0

--- a/spec/jortt/client/tradenames_spec.rb
+++ b/spec/jortt/client/tradenames_spec.rb
@@ -19,5 +19,11 @@ describe Jortt::Client::Tradenames, :vcr do
         'company_name' => 'jortt-ruby gem',
       )
     end
+
+    context "with no tradenames available" do
+      it "returns an empty array" do
+        expect(subject).to eq []
+      end
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,7 +16,7 @@ VCR.configure do |c|
     i.request.headers.delete('Authorization')
     i.response.headers.delete('Set-Cookie')
 
-    if JSON.parse(i.response.body)['access_token']
+    if !i.response.body.empty? && JSON.parse(i.response.body).is_a?(Hash) && JSON.parse(i.response.body)['access_token']
       i.response.body = JSON.parse(i.response.body).tap { |b| b['access_token'] = 'access_token' }.to_json
     end
   end


### PR DESCRIPTION
Fixes error on requesting tradenames from a Jortt account which has no tradenames available.

```
Failure/Error: response.parsed.fetch('data')

TypeError:
  no implicit conversion of String into Integer
# ./lib/jortt/client.rb:171:in `fetch'
# ./lib/jortt/client.rb:171:in `handle_response'
# ./lib/jortt/client.rb:151:in `get'
# ./lib/jortt/client/tradenames.rb:20:in `index'
# ./spec/jortt/client/tradenames_spec.rb:9:in `block (3 levels) in <top (required)>'
# ./spec/jortt/client/tradenames_spec.rb:25:in `block (4 levels) in <top (required)>'
# /usr/local/rvm/gems/default/gems/webmock-3.18.1/lib/webmock/rspec.rb:37:in `block (2 levels) in <top (required)>'
```