### PR TITLE
Raise ServerError for unknown HTTP errors like 502 Bad Gateway

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -17,12 +17,14 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true
+      - name: Update bundler
+        run: gem update --system 3.4.22 && bundle update --bundler
       - name: Run tests
         run: bundle exec rspec
       - name: rubocop

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -12,7 +12,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - ruby-version: 3.0.0
+          - ruby-version: 3.3
+          - ruby-version: 3.2
+          - ruby-version: 3.1
+          - ruby-version: 3.0.7
           - ruby-version: 2.7
 
     steps:

--- a/spec/fixtures/vcr_cassettes/Jortt_Client_Error/502_Bad_Gateway/raises_ServerError.yml
+++ b/spec/fixtures/vcr_cassettes/Jortt_Client_Error/502_Bad_Gateway/raises_ServerError.yml
@@ -1,0 +1,106 @@
+---
+http_interactions:
+  - request:
+      method: post
+      uri: https://app.jortt.nl/oauth-provider/oauth/token
+      body:
+        encoding: UTF-8
+        string: grant_type=client_credentials&scope=invoices%3Aread+invoices%3Awrite+customers%3Aread+customers%3Awrite+organizations%3Aread
+      headers:
+        User-Agent:
+          - Faraday v2.7.6
+        Content-Type:
+          - application/x-www-form-urlencoded
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Date:
+          - Mon, 12 Aug 2024 16:49:42 GMT
+        Content-Type:
+          - application/json; charset=utf-8
+        Transfer-Encoding:
+          - chunked
+        Connection:
+          - keep-alive
+        Status:
+          - 200 OK
+        Cache-Control:
+          - no-store
+        Vary:
+          - Accept
+        Referrer-Policy:
+          - strict-origin-when-cross-origin
+        X-Permitted-Cross-Domain-Policies:
+          - none
+        X-Xss-Protection:
+          - '0'
+        X-Request-Id:
+          - 7e9e9638-9c57-4524-9d69-6bef559b2569
+        X-Download-Options:
+          - noopen
+        Etag:
+          - W/"2973531e45a491eae2fe951b11ca7516"
+        X-Frame-Options:
+          - SAMEORIGIN
+        X-Runtime:
+          - '0.457547'
+        X-Content-Type-Options:
+          - nosniff
+        X-Powered-By:
+          - Phusion Passenger(R)
+        Server:
+          - nginx + Phusion Passenger(R)
+      body:
+        encoding: UTF-8
+        string: '{"access_token":"access_token","token_type":"Bearer","expires_in":7200,"scope":"invoices:read
+        invoices:write customers:read customers:write organizations:read","created_at":1723481381}'
+    recorded_at: Mon, 12 Aug 2024 16:49:42 GMT
+  - request:
+      method: get
+      uri: https://api.jortt.nl/customers/1aa9cd93-aa14-4184-ba01-1fa2776d2e2d
+      body:
+        encoding: US-ASCII
+        string: ''
+      headers:
+        User-Agent:
+          - Faraday v2.7.6
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+    response:
+      status:
+        code: 502
+        message: Bad Gateway
+      headers:
+        Date:
+          - Mon, 12 Aug 2024 16:49:42 GMT
+        Content-Type:
+          - application/html
+        Content-Length:
+          - '974'
+        Connection:
+          - keep-alive
+        Server:
+          - Apache
+        Vary:
+          - X-Forwarded-For
+        Status:
+          - 502 Bad Gateway
+      body:
+        encoding: UTF-8
+        string: |
+          <html>
+          <head><title>502 Bad Gateway</title></head>
+          <body>
+          <center><h1>502 Bad Gateway</h1></center>
+          </body>
+          </html>
+    recorded_at: Mon, 12 Aug 2024 16:49:42 GMT
+recorded_with: VCR 6.1.0

--- a/spec/fixtures/vcr_cassettes/Jortt_Client_Error/raises_Jortt_Client_JorttError.yml
+++ b/spec/fixtures/vcr_cassettes/Jortt_Client_Error/raises_Jortt_Client_JorttError.yml
@@ -1,0 +1,128 @@
+---
+http_interactions:
+  - request:
+      method: post
+      uri: https://app.jortt.nl/oauth-provider/oauth/token
+      body:
+        encoding: UTF-8
+        string: grant_type=client_credentials&scope=invoices%3Aread+invoices%3Awrite+customers%3Aread+customers%3Awrite+organizations%3Aread
+      headers:
+        User-Agent:
+          - Faraday v2.7.6
+        Content-Type:
+          - application/x-www-form-urlencoded
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+    response:
+      status:
+        code: 200
+        message: OK
+      headers:
+        Date:
+          - Tue, 13 Aug 2024 08:16:51 GMT
+        Content-Type:
+          - application/json; charset=utf-8
+        Transfer-Encoding:
+          - chunked
+        Connection:
+          - keep-alive
+        Status:
+          - 200 OK
+        Cache-Control:
+          - no-store
+        Vary:
+          - Accept
+        Referrer-Policy:
+          - strict-origin-when-cross-origin
+        X-Permitted-Cross-Domain-Policies:
+          - none
+        X-Xss-Protection:
+          - '0'
+        X-Request-Id:
+          - bef9fa34-c7b6-4628-89a5-440b48c39bdd
+        X-Download-Options:
+          - noopen
+        Etag:
+          - W/"0b5388279f6c4c980d5cf6cfc6bda06d"
+        X-Frame-Options:
+          - SAMEORIGIN
+        X-Runtime:
+          - '0.561889'
+        X-Content-Type-Options:
+          - nosniff
+        X-Powered-By:
+          - Phusion Passenger(R)
+        Server:
+          - nginx + Phusion Passenger(R)
+      body:
+        encoding: UTF-8
+        string: '{"access_token":"access_token","token_type":"Bearer","expires_in":7200,"scope":"invoices:read
+        invoices:write customers:read customers:write organizations:read","created_at":1723537011}'
+    recorded_at: Tue, 13 Aug 2024 08:16:51 GMT
+  - request:
+      method: get
+      uri: https://api.jortt.nl/customers/999
+      body:
+        encoding: US-ASCII
+        string: ''
+      headers:
+        User-Agent:
+          - Faraday v2.7.6
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+    response:
+      status:
+        code: 422
+        message: Unprocessable Entity
+      headers:
+        Date:
+          - Tue, 13 Aug 2024 08:16:51 GMT
+        Content-Type:
+          - application/json
+        Content-Length:
+          - '225'
+        Connection:
+          - keep-alive
+        Server:
+          - Apache
+        Vary:
+          - X-Forwarded-For
+        Status:
+          - 422 Unprocessable Entity
+        Content-Security-Policy:
+          - 'default-src ''self'' ''unsafe-inline'' blob: data: *.acc.jortt.nl;     script-src
+        ''self'' ''unsafe-eval'' blob: ''unsafe-inline'' files.acc.jortt.nl *.googletagmanager.com
+        *.uservoice.com inlinemanual.com *.google-analytics.com https://www.googleanalytics.com
+        *.googleadservices.com bat.bing.com https://*.tapfiliate.com static.ads-twitter.com
+        tagmanager.google.com analytics.twitter.com https://connect.facebook.net https://app.inlinemanual.com
+        https://cdn.inlinemanual.com https://optimize.google.com https://www.googleoptimize.com
+        https://tpc.googlesyndication.com googleads.g.doubleclick.net *.cookiebot.com
+        *.redditstatic.com;     connect-src ''self'' https://*.acc.jortt.nl wss://*.acc.jortt.nl
+        analytics.inlinemanual.com files.acc.jortt.nl *.google-analytics.com stats.g.doubleclick.net
+        file-storage-app-acceptance.s3.eu-central-1.amazonaws.com https://app.inlinemanual.com
+        https://appsignal-endpoint.net bat.bing.com *.googlesyndication.com *.google.com
+        *.cookiebot.com *.g.doubleclick.net;     style-src ''self'' ''unsafe-inline''
+        fonts.googleapis.com files.acc.jortt.nl tagmanager.google.com https://app.inlinemanual.com
+        https://optimize.google.com https://fonts.googleapis.com https://cdn.inlinemanual.com;     font-src
+        ''self'' data: fonts.gstatic.com files.acc.jortt.nl https://app.inlinemanual.com
+        https://cdn.inlinemanual.com;     frame-src ''self'' *.acc.jortt.nl files.acc.jortt.nl
+        b.frstre.com beacon.tapfiliate.com jortt.uservoice.com *.vimeo.com https://connect.facebook.net
+        https://optimize.google.com https://tpc.googlesyndication.com/ *.cookiebot.com
+        *.doubleclick.net;     img-src ''self'' blob: data: *.acc.jortt.nl https://www.facebook.com
+        files.acc.jortt.nl *.google-analytics.com https://optimize.google.com stats.g.doubleclick.net
+        www.google.nl www.google.com bat.bing.com googleads.g.doubleclick.net https://www.googletagmanager.com
+        https://widget.uservoice.com www.google.de t.co *.gstatic.com https://ssl.google-analytics.com
+        https://app.inlinemanual.com https://*.jf79.net https://jf79.net https://analytics.twitter.com
+        https://cdn.inlinemanual.com *.googlesyndication.com *.reddit.com *.cookiebot.com;     frame-ancestors
+        ''self'' https://*.acc.jortt.nl files.acc.jortt.nl;'
+      body:
+        encoding: UTF-8
+        string: '{"error":{"code":422,"key":"params.invalid","message":"The parameters
+        are invalid (either missing, not of the correct type or incorrect format).","details":[{"key":"is_invalid","param":"customer_id","message":"is
+        invalid"}]}}'
+    recorded_at: Tue, 13 Aug 2024 08:16:51 GMT
+recorded_with: VCR 6.1.0

--- a/spec/jortt/client/error_spec.rb
+++ b/spec/jortt/client/error_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Jortt::Client::Error, :vcr do
+  let(:client) { jortt_client }
+
+  it 'raises Jortt::Client::JorttError' do
+    expect do
+      client.customers.show(999)
+    end.to raise_error do |error|
+      expect(error).to be_a(Jortt::Client::Error)
+      expect(error).to be_an_instance_of(Jortt::Client::JorttError)
+      expect(error).to have_attributes(
+        code: 422,
+        key: 'params.invalid',
+        message: 'The parameters are invalid (either missing, not of the correct type or incorrect format).',
+        details: [{'key' => 'is_invalid','param' => 'customer_id','message' => 'is invalid'}],
+      )
+    end
+  end
+
+  context '502 Bad Gateway' do
+    it 'raises ServerError' do
+      expect do
+        client.customers.show('1aa9cd93-aa14-4184-ba01-1fa2776d2e2d')
+      end.to raise_error do |error|
+        expect(error).to be_a(Jortt::Client::Error)
+        expect(error).to be_an_instance_of(Jortt::Client::ServerError)
+        expect(error).to have_attributes(
+          status: 502,
+          message: 'Bad Gateway',
+          body: "<html>\n<head><title>502 Bad Gateway</title></head>\n<body>\n<center><h1>502 Bad Gateway</h1></center>\n</body>\n</html>\n",
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
Every now and then jortt.shop receives a 502 Bad Gateway. Unfortunately the Jortt client library errors out because the response can't be parsed:

<img width="1091" alt="Screenshot 2024-08-13 at 11 19 51" src="https://github.com/user-attachments/assets/15cf27fb-cd6c-4d92-acfc-9fa7d8d9c3ff">

For jortt.shop to be able to handle this situation, we need the Jortt client library to be able to "handle" this unknown error. 
For such an unknown server error, like a 502 Bad Gateway, this client library should raise a ServerError and have normal Jortt errors raise a JorttError.