### PR TITLE
Remove default `expenses:read` scope

### DIFF
--- a/lib/jortt/client.rb
+++ b/lib/jortt/client.rb
@@ -68,7 +68,7 @@ module Jortt
       else
         # Use client credentials grant type
         @token = client.client_credentials.get_token(
-          scope: opts[:scope] || 'invoices:read invoices:write customers:read customers:write organizations:read expenses:read',
+          scope: opts[:scope] || 'invoices:read invoices:write customers:read customers:write organizations:read',
         )
       end
     end


### PR DESCRIPTION
Adding this default scope will make requests fail for all Jortt client invocations (without a specific set of scopes) for OAuth2 applications without the `expenses:read` scope.

This reverts commit 8882ab8af587e9df84573b05e72b61ab772a7192.